### PR TITLE
Fallback sg

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ aws_swiss security_group do
   rds_name              "my-rds-instance-name"
   cidr                  cidr
   enable                true           # false to revoke
+  fallback_group        "fallback-security-group"
 end
 ````
 
 The `security_group` designation can be specified either as a security group name (for EC2 Classic security groups, or for security groups in the default VPC) or as a security group ID (for VPC security groups). It is recommended to use a specially designated Security Group in order to isolate the dynamic ingresses from any others. For example, your instance's "main" Security Group may be named `db-prod` and allow access to your EC2 Security Groups `web` and `jenkins`. Don't use that group in `aws_swiss`. Instead, your instance should also have an additional Security Group such as `db-prod-swiss` which should be used by `aws_swiss`, specified in `[:aws_swiss][:security_group]`.
+
+The `fallback_group` will be used for RDS secrity groups when the primary `security_group` fails to add the ingress. This can happen when the security group has reached the limit of allowed authorizations (currently a measly 20).
 
 You can omit the `cidr` attribute, in which case the CIDR IP will be the instance's public IP address reported by the AWS Instance Metadata, with a mask of `/32`.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ end
 
 The `cidr_list` attribute should be an Array of String CIDRs, e.g. `[ "1.2.3.4/32", "9.8.0.0/16" ]`.
 
+The `fallback_group` attribute is optional.
+
 You can omit the `aws_access_key_id` and `aws_secret_access_key` attributes, in which case the invocation of the `aws cli` will rely on the instance role's permissions. See below for the exact permissions required.
 
 ## Convenience Recipe: poke

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Issues? https://github.com/shlomoswidler/aws_swiss/issues
 
 # Usage
 
-This cookbook provides two Definition `aws_swiss` that can be used directly. This cookbook also provides two convenience recipes, which can be used to poke or plug holes for the current server.
+This cookbook provides two definitions that can be used directly, `aws_swiss` and `swiss_rds_enforcer`. This cookbook also provides three convenience recipes, which can be used to poke or plug holes for the current server and to enforce the holes for the current OpsWorks Stack.
 
 ## Definition: aws_swiss
 
@@ -60,13 +60,32 @@ aws_swiss security_group do
 end
 ````
 
-The `security_group` designation can be specified either as a security group name (for EC2 Classic security groups, or for security groups in the default VPC) or as a security group ID (for VPC security groups). It is recommended to use a specially designated Security Group in order to isolate the dynamic ingresses from any others. For example, your instance's "main" Security Group may be named `db-prod` and allow access to your EC2 Security Groups `web` and `jenkins`. Don't use that group in `aws_swiss`. Instead, your instance should also have an additional Security Group such as `db-prod-swiss` which should be used by `aws_swiss`, specified in `[:aws_swiss][:security_group]`.
+The `security_group` designation can be specified either as a security group name (for EC2 Classic security groups, or for security groups in the default VPC, or for RDS DB security groups) or as a security group ID (for VPC security groups). It is recommended to use a specially designated Security Group in order to isolate the dynamic ingresses from any others. For example, your instance's "main" Security Group may be named `db-prod` and allow access to your EC2 Security Groups `web` and `jenkins`. Don't use that group in `aws_swiss`. Instead, your instance should also have an additional Security Group such as `db-prod-swiss` which should be used by `aws_swiss`, specified in `[:aws_swiss][:security_group]`.
 
 The `fallback_group` will be used for RDS secrity groups when the primary `security_group` fails to add the ingress. This can happen when the security group has reached the limit of allowed authorizations (currently a measly 20).
 
 You can omit the `cidr` attribute, in which case the CIDR IP will be the instance's public IP address reported by the AWS Instance Metadata, with a mask of `/32`.
 
 You can omit the `enable` attribute, whose default value is `true`.
+
+You can omit the `aws_access_key_id` and `aws_secret_access_key` attributes, in which case the invocation of the `aws cli` will rely on the instance role's permissions. See below for the exact permissions required.
+
+## Definition: swiss_rds_enforcer
+
+Occasionally, holes may be left in the security group unnecessarily (such as when an instance fails to complete its shutdown Chef run) or holes may be missing from the security group (such as when an instance changes its IP address). The `swiss_rds_enforcer` definition can be used to bring RDS DB Secrity Groups into agreement with a known list of CIDRs, as follows:
+
+````
+swiss_rds_enforcer do
+  aws_access_key_id     aws_access_key # optional
+  aws_secret_access_key aws_secret_key # optional
+  region                node[:opsworks][:instance][:region] # or another region if you know better
+  cidr_list             array_of_cidrs
+  security_group        "security-group"
+  fallback_group        "fallback-security-group"
+end
+````
+
+The `cidr_list` attribute should be an Array of String CIDRs, e.g. `[ "1.2.3.4/32", "9.8.0.0/16" ]`.
 
 You can omit the `aws_access_key_id` and `aws_secret_access_key` attributes, in which case the invocation of the `aws cli` will rely on the instance role's permissions. See below for the exact permissions required.
 
@@ -78,9 +97,13 @@ The `poke` recipe enables a security group ingress for the current server's publ
 
 The `plug` recipe revokes the security group ingress for the current server's public IP addess.
 
+## Convenience Recipe: enforce
+
+The `enforce` recipe enforces the security group ingresses for the current OpsWorks Stack's instances' public IP addresses.
+
 # Configuration
 
-The convenience recipes `poke` and `plug` require the following configuration:
+The convenience recipes `poke`, `plug`, and `enforce` require the following configuration:
 
 ````
 "aws_swiss": {
@@ -88,10 +111,11 @@ The convenience recipes `poke` and `plug` require the following configuration:
   "aws_secret_access_key": "AWS Secret Access Key",
   "security_group":        "security-group-name-or-ID",
   "port":                  "3306"         # only needed for EC2 security groups
+  "fallback_group":        "fallback-security-group-name" # optional, for RDS
 }
 ````
 **In the above JSON, only specify the `port` option if the security group is an EC2 security group.**
-Also, the `aws_access_key_id` and `aws_secret_access_key` JSON settings are optional.
+Also, the `aws_access_key_id`, `aws_secret_access_key`, and `fallback_group` attributes are optional.
 
 ## AWS Credentials
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ end
 
 ````
 
-To poke a hole in an RDS DB Security Group, specify the `rds_name` attribute and omit the `port` attribute, as follows:
+To poke a hole in an RDS DB Security Group, omit the `port` attribute, as follows:
 
 ````
 aws_access_key = "AKIA....."
@@ -54,7 +54,6 @@ cidr           = "1.2.3.4/32"
 aws_swiss security_group do
   aws_access_key_id     aws_access_key # optional
   aws_secret_access_key aws_secret_key # optional
-  rds_name              "my-rds-instance-name"
   cidr                  cidr
   enable                true           # false to revoke
   fallback_group        "fallback-security-group"
@@ -88,11 +87,10 @@ The convenience recipes `poke` and `plug` require the following configuration:
   "aws_access_key_id":     "AWS Access Key ID",
   "aws_secret_access_key": "AWS Secret Access Key",
   "security_group":        "security-group-name-or-ID",
-  "rds_name":              "short-name-of-rds-instance",
-  "port":                  "3306"
+  "port":                  "3306"         # only needed for EC2 security groups
 }
 ````
-**In the above JSON, only specify one of the `port` or `rds_name` options.**
+**In the above JSON, only specify the `port` option if the security group is an EC2 security group.**
 Also, the `aws_access_key_id` and `aws_secret_access_key` JSON settings are optional.
 
 ## AWS Credentials

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -65,8 +65,8 @@ do
             if shell.exitstatus != 0
               # failed to poke hole.
               if !fallback_group.nil?
-                Chef::Log.info('STDOUT:' + shell.stdout)
-                Chef::Log.info('STDERR:'+ shell.stderr)
+                Chef::Log.info('STDOUT: ' + shell.stdout)
+                Chef::Log.info('STDERR: '+ shell.stderr)
                 Chef::Log.info("There are #{json['DBSecurityGroups'].first['IPRanges'].size} holes in the security group #{security_group}")
                 # try the fallback SG
                 shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{fallback_group} --cidrip #{cidr}")
@@ -76,15 +76,14 @@ do
               end
               if shell.exitstatus != 0
                 # failed to poke hole and fallback not specified or also failed.
-                Chef::Log.info('STDOUT' + shell.stdout)
-                Chef::Log.fatal('STDERR' + shell.stderr)
+                Chef::Log.info('STDOUT: ' + shell.stdout)
+                Chef::Log.fatal('STDERR: ' + shell.stderr)
                 Chef::Log.info("There are #{json['DBSecurityGroups'].first['IPRanges'].size} holes in the security group #{security_group}")
-                false
+                raise "Failed to authorize RDS ingress for #{target_name}"
               end
             end
             if shell.exitstatus == 0
-              Chef::Log.info(shell.stdout)
-              true
+              Chef::Log.info(shell.stdout) if shell.stdout.length > 0
             end
           else
             Chef::Log.info("RDS ingress for #{target_name} already exists.")

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -10,7 +10,7 @@ do
   security_group = params[:name]
   cidr = params[:cidr]
   port = params[:port]
-  fallback_group = params[:fallback_group]rd
+  fallback_group = params[:fallback_group]
   
   if !port.nil?
     port = port.to_s

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -81,7 +81,7 @@ do
               end
             end
             if shell.exitstatus
-              Chef::Log.info(shell.stdout)
+              Chef::Log.info(shell.format_for_exception)
               true
             end
           else

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -80,10 +80,12 @@ do
                 false
               end
             end
-            if shell.exit_status
+            if shell.exitstatus
               Chef::Log.info(shell.stdout)
               true
             end
+          else
+            Chef::Log.info("RDS ingress for #{target_name} already exists.")
           end
         end
       end

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -37,19 +37,7 @@ do
     if port.nil? # RDS security group
       ruby_block "authorize RDS ingress for #{target_name}" do
         block do
-          if !SecurityGroupHoleController.open_rds_hole_if_necessary(security_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
-            # failed to poke hole in specified security group
-            if !fallback_group.nil?
-              Chef::Log.info("Trying to poke hole in fallback security group #{fallback_group}")
-              if !SecurityGroupHoleController.open_rds_hole_if_necessary(fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
-                # failed fallback also
-                raise "Failed to poke hole in fallback security group #{fallback_group}"
-              end
-            else
-              # no fallback security group
-              raise "Failed to poke hole in RDS security group #{security_group} and no fallback group specified"
-            end
-          end
+          SecurityGroupHoleController.open_rds_hole_with_fallback(security_group, fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
         end
       end
     else # EC2 security group
@@ -70,18 +58,7 @@ do
     if port.nil? # RDS security group
       ruby_block "revoke RDS ingress for #{target_name}" do
         block do
-          plugged = SecurityGroupHoleController.close_rds_hole_if_necessary(security_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
-          if plugged
-            # hole is not present in specified security group. Make sure it's not in the fallback group either.
-            if !fallback_group.nil?
-              Chef::Log.info("Plugging hole in fallback security group #{fallback_group}")
-              plugged = SecurityGroupHoleController.close_rds_hole_if_necessary(fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
-            end
-          end
-          if !plugged
-            # failed to plug hole
-            raise "Failed to plug hole in RDS security group #{security_group} fallback group #{fallback_group}"
-          end
+          SecurityGroupHoleController.close_rds_hole_with_fallback(security_group, fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
         end
       end
     else # EC2 security group

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -62,7 +62,7 @@ do
             }
             shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{security_group} --cidrip #{cidr}")
             shell.run_command
-            if !shell.exitstatus
+            if shell.exitstatus != 0
               # failed to poke hole.
               if !fallback_group.nil?
                 Chef::Log.info('STDOUT:' + shell.stdout)
@@ -71,8 +71,10 @@ do
                 # try the fallback SG
                 shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{fallback_group} --cidrip #{cidr}")
                 shell.run_command
+              else
+                Chef::Log.info('No fallback_group set')
               end
-              if !shell.exitstatus
+              if shell.exitstatus != 0
                 # failed to poke hole and fallback not specified or also failed.
                 Chef::Log.info('STDOUT' + shell.stdout)
                 Chef::Log.fatal('STDERR' + shell.stderr)
@@ -80,8 +82,8 @@ do
                 false
               end
             end
-            if shell.exitstatus
-              Chef::Log.info(shell.format_for_exception)
+            if shell.exitstatus == 0
+              Chef::Log.info(shell.stdout)
               true
             end
           else

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -3,18 +3,14 @@ define :aws_swiss, \
   :aws_secret_access_key => nil, \
   :cidr => nil, \
   :port => nil, \
-  :rds_name => nil, \
   :enable => true, \
   :fallback_group => nil \
 do
 
   security_group = params[:name]
-  rds_name = params[:rds_name]
   cidr = params[:cidr]
   port = params[:port]
-  fallback_group = params[:fallback_group]
-  
-  raise "Illegal use of aws_swiss definition: only one of 'port' and 'rds_name' must be specified" if rds_name.nil? == port.nil?
+  fallback_group = params[:fallback_group]rd
   
   if !port.nil?
     port = port.to_s
@@ -46,7 +42,7 @@ do
   command_base << "/usr/local/bin/aws --region #{region} "
 
   target_name = "CIDR #{cidr}" + (port.nil? ? "" : " port #{port}") + " to " +
-    (port.nil? ? "rds instance #{rds_name} " : "") +  "security group #{security_group}"
+    (port.nil? ? "RDS DB " : "") +  "security group #{security_group}"
 
   include_recipe "awscli"
   require 'json'

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -62,6 +62,7 @@ do
             }
             shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{security_group} --cidrip #{cidr}")
             shell.run_command
+            succeeded = false
             if shell.exitstatus != 0
               # failed to poke hole.
               if !fallback_group.nil?
@@ -78,11 +79,12 @@ do
                   shell.run_command
                 else
                   Chef::Log.info("Fallback security group #{fallback_group} already contains ingress for CIDR #{cidr}")
+                  succeeded = true
                 end
               else
                 Chef::Log.info('No fallback_group set')
               end
-              if shell.exitstatus != 0
+              if shell.exitstatus != 0 || succeeded
                 # failed to poke hole and fallback not specified or also failed.
                 Chef::Log.info('STDOUT: ' + shell.stdout)
                 Chef::Log.fatal('STDERR: ' + shell.stderr)

--- a/definitions/aws_swiss.rb
+++ b/definitions/aws_swiss.rb
@@ -65,7 +65,8 @@ do
             if !shell.exitstatus
               # failed to poke hole.
               if !fallback_group.nil?
-                Chef::Log.info(shell.stderr)
+                Chef::Log.info('STDOUT:' + shell.stdout)
+                Chef::Log.info('STDERR:'+ shell.stderr)
                 Chef::Log.info("There are #{json['DBSecurityGroups'].first['IPRanges'].size} holes in the security group #{security_group}")
                 # try the fallback SG
                 shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{fallback_group} --cidrip #{cidr}")
@@ -73,10 +74,15 @@ do
               end
               if !shell.exitstatus
                 # failed to poke hole and fallback not specified or also failed.
-                Chef::Log.fatal(shell.stderr)
+                Chef::Log.info('STDOUT' + shell.stdout)
+                Chef::Log.fatal('STDERR' + shell.stderr)
                 Chef::Log.info("There are #{json['DBSecurityGroups'].first['IPRanges'].size} holes in the security group #{security_group}")
                 false
               end
+            end
+            if shell.exit_status
+              Chef::Log.info(shell.stdout)
+              true
             end
           end
         end

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -22,14 +22,16 @@ do
         result
       }
   
-      extra_holes, confirmed_holes = holes.partition {|cidr| !cidr_list.include?(cidr) }
-      missing_holes, more_confirmed_holes = cidr_list.partition {|cidr| !holes.include?(cidr) }
+      Chef::Log.info("Existing holes: #{holes.join(',')")
+      
+      confirmed_holes, extra_holes = holes.partition {|cidr| cidr_list.include?(cidr) }
+      more_confirmed_holes, missing_holes = cidr_list.partition {|cidr| holes.include?(cidr) }
       
       # TODO: plug extra_holes (may require moving functionality into the library module)
-      Chef::Log.info("Extra holes: #{extra_holes.join(',')}")
+      Chef::Log.info("#{extra_holes.size} extra holes: #{extra_holes.join(',')}")
       
       # TODO: poke missing_holes (likewise)
-      Chef::Log.info("Missing holes: #{missing_holes.join(',')}")
+      Chef::Log.info("#{missing_holes.size} missing holes: #{missing_holes.join(',')}")
       
     end
   end

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -3,12 +3,16 @@ define :swiss_rds_enforcer, \
   :aws_secret_access_key => nil, \
   :region => nil, \
   :cidr_list => nil, \
-  :security_group_list => nil \
+  :security_group => nil, \
+  :fallback_group => nil \
 do
-
-  security_group_list = params[:security_group_list]
-  if security_group_list.is_a? String
-    security_group_list = security_group_list.split(',')
+  if params[:security_group].nil?
+    raise "swiss_rds_enforcer definition: security_group must be specified"
+  end
+  
+  security_group_list = [ params[:security_group] ]
+  if params[:fallback_group]
+    security_group_list << params[:fallback_group]
   end
   cidr_list = params[:cidr_list]
   if cidr_list.is_a? String
@@ -27,12 +31,15 @@ do
       confirmed_holes, extra_holes = holes.partition {|cidr| cidr_list.include?(cidr) }
       more_confirmed_holes, missing_holes = cidr_list.partition {|cidr| holes.include?(cidr) }
       
-      # TODO: plug extra_holes (may require moving functionality into the library module)
-      Chef::Log.info("#{extra_holes.size} extra holes: #{extra_holes.sort.join(',')}")
+      Chef::Log.info("Plugging #{extra_holes.size} extra holes: #{extra_holes.sort.join(',')}")
+      extra_holes.each { |cidr|
+        SecurityGroupHoleController.close_rds_hole_with_fallback(params[:security_group], params[:fallback_group], cidr, params[:region], params[:aws_access_key_id], params[:aws_secret_access_key])
+      }
       
-      # TODO: poke missing_holes (likewise)
-      Chef::Log.info("#{missing_holes.size} missing holes: #{missing_holes.sort.join(',')}")
-      
+      Chef::Log.info("Poking #{missing_holes.size} missing holes: #{missing_holes.sort.join(',')}")
+      missing_holes.each { |cidr|
+        SecurityGroupHoleController.open_rds_hole_with_fallback(params[:security_group], params[:fallback_group], cidr, params[:region], params[:aws_access_key_id], params[:aws_secret_access_key])
+      }
     end
   end
   

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -1,0 +1,36 @@
+define :swiss_rds_enforcer, \
+  :aws_access_key_id => nil, \
+  :aws_secret_access_key => nil, \
+  :region => nil, \
+  :cidr_list => nil, \
+  :security_group_list => nil \
+do
+
+  security_group_list = params[:security_group_list]
+  if security_group_list.is_a? String
+    security_group_list = security_group_list.split(',')
+  end
+  cidr_list = params[:cidr_list]
+  if cidr_list.is_a? String
+    cidr_list = cidr_list.split(',')
+  end
+  
+  ruby_block "enforce rds security group holes for security groups #{security_group_list.join(',')}" do
+    block do
+      holes = security_group_list.reduce([]) {|result, group|
+        result << SecurityGroupHoleController.get_rds_cidr_holes(group, params[:region], params[:aws_access_key_id], params[:aws_secret_access_key])
+        result
+      }
+  
+      extra_holes, confirmed_holes = holes.partition {|cidr| !cidr_list.include?(cidr) }
+      missing_holes, more_confirmed_holes = cidr_list.partition {|cidr| !holes.include?(cidr) }
+      
+      # TODO: plug extra_holes (may require moving functionality into the library module)
+      
+      # TODO: poke missing_holes (likewise)
+      
+    end
+  end
+  
+  
+end

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -26,8 +26,10 @@ do
       missing_holes, more_confirmed_holes = cidr_list.partition {|cidr| !holes.include?(cidr) }
       
       # TODO: plug extra_holes (may require moving functionality into the library module)
+      Chef::Log.info("Extra holes: #{extra_holes.join(',')}")
       
       # TODO: poke missing_holes (likewise)
+      Chef::Log.info("Missing holes: #{missing_holes.join(',')}")
       
     end
   end

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -18,7 +18,7 @@ do
   ruby_block "enforce rds security group holes for security groups #{security_group_list.join(',')}" do
     block do
       holes = security_group_list.reduce([]) {|result, group|
-        result << SecurityGroupHoleController.get_rds_cidr_holes(group, params[:region], params[:aws_access_key_id], params[:aws_secret_access_key])
+        result = result + SecurityGroupHoleController.get_rds_cidr_holes(group, params[:region], params[:aws_access_key_id], params[:aws_secret_access_key])
         result
       }
   

--- a/definitions/swiss_rds_enforcer.rb
+++ b/definitions/swiss_rds_enforcer.rb
@@ -22,16 +22,16 @@ do
         result
       }
   
-      Chef::Log.info("Existing holes: #{holes.join(',')")
+      Chef::Log.info("#{holes.size} existing holes: #{holes.sort.join(',')}")
       
       confirmed_holes, extra_holes = holes.partition {|cidr| cidr_list.include?(cidr) }
       more_confirmed_holes, missing_holes = cidr_list.partition {|cidr| holes.include?(cidr) }
       
       # TODO: plug extra_holes (may require moving functionality into the library module)
-      Chef::Log.info("#{extra_holes.size} extra holes: #{extra_holes.join(',')}")
+      Chef::Log.info("#{extra_holes.size} extra holes: #{extra_holes.sort.join(',')}")
       
       # TODO: poke missing_holes (likewise)
-      Chef::Log.info("#{missing_holes.size} missing holes: #{missing_holes.join(',')}")
+      Chef::Log.info("#{missing_holes.size} missing holes: #{missing_holes.sort.join(',')}")
       
     end
   end

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -13,15 +13,22 @@ module SecurityGroupHoleController
     security_group[/sg-([0-9a-f]{8})/, 1].nil? ? "group-name" : "group-id"
   end
   
-  # private
-  def self.detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+  def self.get_rds_cidr_holes(security_group, region, aws_access_key_id, aws_secret_access_key)
     command_base = awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)
     str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
     json=JSON.parse(str)
+    json['DBSecurityGroups'].first['IPRanges'].reduce([]) { |result, cidrHash| 
+      if ["authorized", "authorizing"].include?(cidrHash['Status'])
+        result << cidrHash['CIDRIP']
+      end
+      result
+    }
+  end
+  
+  def self.detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+    cidr_holes = get_rds_cidr_holes(security_group, region, aws_access_key_id, aws_secret_access_key)
     # the return value - array of [ hole_exists, num_holes ]
-    [ json['DBSecurityGroups'].first['IPRanges'].any? { | cidrHash | 
-      cidrHash['CIDRIP'] == cidr && ["authorized", "authorizing"].include?(cidrHash['Status']) },
-      json['DBSecurityGroups'].first['IPRanges'].size ]
+    [ cidr_holes.include?(cidr), cidr_holes.size ]
   end
   
   def self.open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
@@ -75,4 +82,5 @@ module SecurityGroupHoleController
       true
     end
   end
+  
 end

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -12,6 +12,7 @@ module SecurityGroupHoleController
   
   # private
   def self.detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+    command_base = awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)
     str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
     json=JSON.parse(str)
     # the return value - array of [ hole_exists, num_holes ]
@@ -21,7 +22,6 @@ module SecurityGroupHoleController
   end
   
   def self.open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
-    
     hole_exists, num_holes = detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
     if !hole_exists
       command_base = awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -88,7 +88,7 @@ module SecurityGroupHoleController
       # failed to poke hole in specified security group
       if !fallback_group.nil?
         Chef::Log.info("Trying to poke hole in fallback security group #{fallback_group}")
-        if !SecurityGroupHoleController.open_rds_hole_if_necessary(fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
+        if !open_rds_hole_if_necessary(fallback_group, cidr, region, aws_access_key_id, aws_secret_access_key)
           # failed fallback also
           raise "Failed to poke hole in fallback security group #{fallback_group}"
         end

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -1,8 +1,7 @@
 module SecurityGroupHoleController
-
-  @unused_module_variable = false
   
-  def self.PRIVATE_detect_rds_hole(command_base, security_group, cidr)
+  # private
+  def self.detect_rds_hole(command_base, security_group, cidr)
     str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
     json=JSON.parse(str)
     # the return value - array of [ hole_exists, num_holes ]
@@ -24,14 +23,14 @@ module SecurityGroupHoleController
       shell.run_command
       if shell.exitstatus != 0
         # failed to poke hole.
-        Chef::Log.info('Failed to poke hole in RDS security group #{security_group} for cidr #{cidr}')
+        Chef::Log.info("Failed to poke hole in RDS security group #{security_group} for cidr #{cidr}")
         Chef::Log.info('STDOUT: ' + shell.stdout)
         Chef::Log.info('STDERR: '+ shell.stderr)
         Chef::Log.info("There are #{num_holes} holes in the security group #{security_group}")
         false
       else
         # hole poked successfully
-        Chef::Log.info('Successfully poked hole in RDS security group #{security_group} for cidr #{cidr}')
+        Chef::Log.info("Successfully poked hole in RDS security group #{security_group} for cidr #{cidr}")
         Chef::Log.info("There are now #{num_holes+1} holes in the security group #{security_group}")
         true
       end

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -105,7 +105,7 @@ module SecurityGroupHoleController
       # hole is not present in specified security group. Make sure it's not in the fallback group either.
       if !fallback_group.nil?
         Chef::Log.info("Plugging hole in fallback security group #{fallback_group}")
-        plugged = close_rds_hole_if_necessary(fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
+        plugged = close_rds_hole_if_necessary(fallback_group, cidr, region, aws_access_key_id, aws_secret_access_key)
       end
     end
     if !plugged

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -83,4 +83,20 @@ module SecurityGroupHoleController
     end
   end
   
+  def self.open_rds_hole_with_fallback(security_group, fallback_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+    if !open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+      # failed to poke hole in specified security group
+      if !fallback_group.nil?
+        Chef::Log.info("Trying to poke hole in fallback security group #{fallback_group}")
+        if !SecurityGroupHoleController.open_rds_hole_if_necessary(fallback_group, cidr, region, params[:aws_access_key_id], params[:aws_secret_access_key])
+          # failed fallback also
+          raise "Failed to poke hole in fallback security group #{fallback_group}"
+        end
+      else
+        # no fallback security group
+        raise "Failed to poke hole in RDS security group #{security_group} and no fallback group specified"
+      end
+    end
+  end
+  
 end

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -1,7 +1,17 @@
 module SecurityGroupHoleController
   
   # private
-  def self.detect_rds_hole(command_base, security_group, cidr)
+  def self.awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)
+    command_base = ""
+    if !aws_access_key_id.nil? && !aws_secret_access_key.nil?
+      command_base = "AWS_ACCESS_KEY_ID=#{aws_access_key_id} AWS_SECRET_ACCESS_KEY=#{aws_secret_access_key} "
+    end
+    command_base << "/usr/local/bin/aws --region #{region} "
+    command_base
+  end
+  
+  # private
+  def self.detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
     str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
     json=JSON.parse(str)
     # the return value - array of [ hole_exists, num_holes ]
@@ -11,14 +21,10 @@ module SecurityGroupHoleController
   end
   
   def self.open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
-    command_base = ""
-    if !aws_access_key_id.nil? && !aws_secret_access_key.nil?
-      command_base = "AWS_ACCESS_KEY_ID=#{aws_access_key_id} AWS_SECRET_ACCESS_KEY=#{aws_secret_access_key} "
-    end
-    command_base << "/usr/local/bin/aws --region #{region} "
     
-    hole_exists, num_holes = PRIVATE_detect_rds_hole(command_base, security_group, cidr)
+    hole_exists, num_holes = detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
     if !hole_exists
+      command_base = awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)
       shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{security_group} --cidrip #{cidr}")
       shell.run_command
       if shell.exitstatus != 0

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -5,10 +5,10 @@ module SecurityGroupHoleController
   def self.PRIVATE_detect_rds_hole(command_base, security_group, cidr)
     str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
     json=JSON.parse(str)
-    # the return value
-    [ json['DBSecurityGroups'].first['IPRanges'].size, 
-      json['DBSecurityGroups'].first['IPRanges'].any? { | cidrHash | 
-      cidrHash['CIDRIP'] == cidr && ["authorized", "authorizing"].include?(cidrHash['Status']) } ]
+    # the return value - array of [ hole_exists, num_holes ]
+    [ json['DBSecurityGroups'].first['IPRanges'].any? { | cidrHash | 
+      cidrHash['CIDRIP'] == cidr && ["authorized", "authorizing"].include?(cidrHash['Status']) },
+      json['DBSecurityGroups'].first['IPRanges'].size ]
   end
   
   def self.open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -9,6 +9,10 @@ module SecurityGroupHoleController
     command_base
   end
   
+  def self.get_awscli_argument_for_security_group(security_group)
+    security_group[/sg-([0-9a-f]{8})/, 1].nil? ? "group-name" : "group-id"
+  end
+  
   # private
   def self.detect_rds_hole(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
     command_base = awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -1,6 +1,5 @@
 module SecurityGroupHoleController
   
-  # private
   def self.awscli_command_stem(region, aws_access_key_id, aws_secret_access_key)
     command_base = ""
     if !aws_access_key_id.nil? && !aws_secret_access_key.nil?

--- a/libraries/security_group_hole_controller.rb
+++ b/libraries/security_group_hole_controller.rb
@@ -1,0 +1,44 @@
+module SecurityGroupHoleController
+
+  @unused_module_variable = false
+  
+  def self.PRIVATE_detect_rds_hole(command_base, security_group, cidr)
+    str=%x^#{command_base} rds describe-db-security-groups --db-security-group-name #{security_group}^
+    json=JSON.parse(str)
+    # the return value
+    [ json['DBSecurityGroups'].first['IPRanges'].size, 
+      json['DBSecurityGroups'].first['IPRanges'].any? { | cidrHash | 
+      cidrHash['CIDRIP'] == cidr && ["authorized", "authorizing"].include?(cidrHash['Status']) } ]
+  end
+  
+  def self.open_rds_hole_if_necessary(security_group, cidr, region, aws_access_key_id, aws_secret_access_key)
+    command_base = ""
+    if !aws_access_key_id.nil? && !aws_secret_access_key.nil?
+      command_base = "AWS_ACCESS_KEY_ID=#{aws_access_key_id} AWS_SECRET_ACCESS_KEY=#{aws_secret_access_key} "
+    end
+    command_base << "/usr/local/bin/aws --region #{region} "
+    
+    hole_exists, num_holes = PRIVATE_detect_rds_hole(command_base, security_group, cidr)
+    if !hole_exists
+      shell = Mixlib::ShellOut.new(command_base + "rds authorize-db-security-group-ingress --db-security-group-name #{security_group} --cidrip #{cidr}")
+      shell.run_command
+      if shell.exitstatus != 0
+        # failed to poke hole.
+        Chef::Log.info('Failed to poke hole in RDS security group #{security_group} for cidr #{cidr}')
+        Chef::Log.info('STDOUT: ' + shell.stdout)
+        Chef::Log.info('STDERR: '+ shell.stderr)
+        Chef::Log.info("There are #{num_holes} holes in the security group #{security_group}")
+        false
+      else
+        # hole poked successfully
+        Chef::Log.info('Successfully poked hole in RDS security group #{security_group} for cidr #{cidr}')
+        Chef::Log.info("There are now #{num_holes+1} holes in the security group #{security_group}")
+        true
+      end
+    else
+      # hole already exists
+      Chef::Log.info("Hole in RDS security group #{security_group} for cidr #{cidr} already exists among #{num_holes} holes")
+      true
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'shlomo.swidler@orchestratus.com'
 license          'Apache 2.0'
 description      "Dynamically poke holes in EC2 and RDS security groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'
 
 supports "ubuntu", ">= 12.04"
 
@@ -12,3 +12,4 @@ depends "awscli", ">= 0.4.0"
 
 recipe "poke", "open a hole for this server"
 recipe "plug", "remove the hole for this server"
+recipe "enforce", "enforce a CIDR list on the security groups"

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,8 +1,9 @@
 if node[:aws_swiss][:port].nil?
-  puts "instances are: #{node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].inspect}"
   
-  this_layers_cidrs = node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].reduce([]) { |result, instance|
-    result << (instance.values.first[:ip] + "/32")
+  this_layer = node[:opsworks][:instance][:layers].first
+  puts "first instance is: #{node[:opsworks][:layers][this_layer][:instances].values.first.inspect}"
+  this_layers_cidrs = node[:opsworks][:layers][this_layer][:instances].values.reduce([]) { |result, instance|
+    result << (instance[:ip] + "/32")
     result
   }
   

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,5 +1,6 @@
 if node[:aws_swiss][:port].nil?
-
+  Chef::Log.debug("instances are: #{node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].inspect}")
+  
   this_layers_cidrs = node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].reduce([]) { |result, instance|
     result << (instance.values.first[:ip] + "/32")
     result

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,7 +1,6 @@
 if node[:aws_swiss][:port].nil?
   
-  # CHANGE TO USE ALL INSTANCES IN THIS STACK
-  # node[:opsworks][:layers][layer-shortname][:instances][instance-shortname][:elastic_ip] OR [:ip]
+  # get cidrs for all instances in this OpsWorks Stack
   this_stacks_cidrs = []
   node[:opsworks][:layers].each { | layer_shortname, layer_desc|
     layer_desc[:instances].values.each{ |instance|

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,19 +1,26 @@
 if node[:aws_swiss][:port].nil?
   
-  this_layer = node[:opsworks][:instance][:layers].first
-  puts "first instance is: #{node[:opsworks][:layers][this_layer][:instances].values.first.inspect}"
-  this_layers_cidrs = node[:opsworks][:layers][this_layer][:instances].values.reduce([]) { |result, instance|
-    result << (instance[:ip] + "/32")
-    result
+  # CHANGE TO USE ALL INSTANCES IN THIS STACK
+  # node[:opsworks][:layers][layer-shortname][:instances][instance-shortname][:elastic_ip] OR [:ip]
+  this_stacks_cidrs = []
+  node[:opsworks][:layers].each { | layer_shortname, layer_desc|
+    layer_desc[:instances].values.each{ |instance|
+      cidr = instance[:elastic_ip]
+      if cidr.nil?
+        cidr = instance[:ip]
+      end
+      this_stacks_cidrs << (cidr + "/32")
+    }
   }
+  this_stacks_cidrs.sort!.uniq!
   
-  Chef::Log.info("#{this_layers_cidrs.size} cidrs in this layer: #{this_layers_cidrs.sort.join(',')}")
+  Chef::Log.info("#{this_stacks_cidrs.size} cidrs in this stack: #{this_stacks_cidrs.join(',')}")
 
   swiss_rds_enforcer do
     aws_access_key_id     node[:aws_swiss][:aws_access_key_id]
     aws_secret_access_key node[:aws_swiss][:aws_secret_access_key]
     region                node[:opsworks][:instance][:region]
-    cidr_list             this_layers_cidrs
+    cidr_list             this_stacks_cidrs
     security_group_list   [ node[:aws_swiss][:security_group], node[:aws_swiss][:fallback_group] ]
   end
 end

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,5 +1,5 @@
 if node[:aws_swiss][:port].nil?
-  Chef::Log.debug("instances are: #{node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].inspect}")
+  puts "instances are: #{node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].inspect}"
   
   this_layers_cidrs = node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].reduce([]) { |result, instance|
     result << (instance.values.first[:ip] + "/32")

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,4 +1,4 @@
-unless node[:aws_swiss][:port].nil?
+if node[:aws_swiss][:port].nil?
 
   this_layers_cidrs = node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].reduce([]) { |result, instance|
     result << (instance.values.first[:ip] + "/32")

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -20,6 +20,7 @@ if node[:aws_swiss][:port].nil?
     aws_secret_access_key node[:aws_swiss][:aws_secret_access_key]
     region                node[:opsworks][:instance][:region]
     cidr_list             this_stacks_cidrs
-    security_group_list   [ node[:aws_swiss][:security_group], node[:aws_swiss][:fallback_group] ]
+    security_group        node[:aws_swiss][:security_group]
+    fallback_group        node[:aws_swiss][:fallback_group]
   end
 end

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -1,0 +1,17 @@
+unless node[:aws_swiss][:port].nil?
+
+  this_layers_cidrs = node[:opsworks][:layers][ node[:opsworks][:instance][:layers].first ][:instances].reduce([]) { |result, instance|
+    result << (instance.values.first[:ip] + "/32")
+    result
+  }
+  
+  Chef::Log.info("cidrs in this layer: #{this_layers_cidrs.join(',')}")
+
+  swiss_rds_enforcer do
+    aws_access_key_id     node[:aws_swiss][:aws_access_key_id]
+    aws_secret_access_key node[:aws_swiss][:aws_secret_access_key]
+    region                node[:opsworks][:instance][:region]
+    cidr_list             this_layers_cidrs
+    security_group_list   [ node[:aws_swiss][:security_group], node[:aws_swiss][:fallback_group] ]
+  end
+end

--- a/recipes/enforce.rb
+++ b/recipes/enforce.rb
@@ -7,7 +7,7 @@ if node[:aws_swiss][:port].nil?
     result
   }
   
-  Chef::Log.info("cidrs in this layer: #{this_layers_cidrs.join(',')}")
+  Chef::Log.info("#{this_layers_cidrs.size} cidrs in this layer: #{this_layers_cidrs.sort.join(',')}")
 
   swiss_rds_enforcer do
     aws_access_key_id     node[:aws_swiss][:aws_access_key_id]

--- a/recipes/plug.rb
+++ b/recipes/plug.rb
@@ -4,4 +4,5 @@ aws_swiss node[:aws_swiss][:security_group] do
   rds_name              node[:aws_swiss][:rds_name] # May be nil - but at least one of 'port' or 'rds_name' must be given
   port                  node[:aws_swiss][:port]     # May be nil - but at least one of 'port' or 'rds_name' must be given
   enable                false
+  fallback_group        node[:aws_swiss][:fallback_group] # May be nil
 end

--- a/recipes/plug.rb
+++ b/recipes/plug.rb
@@ -1,8 +1,7 @@
 aws_swiss node[:aws_swiss][:security_group] do
   aws_access_key_id     node[:aws_swiss][:aws_access_key_id]
   aws_secret_access_key node[:aws_swiss][:aws_secret_access_key]
-  rds_name              node[:aws_swiss][:rds_name] # May be nil - but at least one of 'port' or 'rds_name' must be given
-  port                  node[:aws_swiss][:port]     # May be nil - but at least one of 'port' or 'rds_name' must be given
+  port                  node[:aws_swiss][:port]     # May be nil
   enable                false
   fallback_group        node[:aws_swiss][:fallback_group] # May be nil
 end

--- a/recipes/poke.rb
+++ b/recipes/poke.rb
@@ -1,8 +1,7 @@
 aws_swiss node[:aws_swiss][:security_group] do
   aws_access_key_id     node[:aws_swiss][:aws_access_key_id]
   aws_secret_access_key node[:aws_swiss][:aws_secret_access_key]
-  rds_name              node[:aws_swiss][:rds_name] # May be nil - but at least one of 'port' or 'rds_name' must be given
-  port                  node[:aws_swiss][:port]     # May be nil - but at least one of 'port' or 'rds_name' must be given
+  port                  node[:aws_swiss][:port]     # May be nil
   enable                true
   fallback_group        node[:aws_swiss][:fallback_group] # May be nil
 end

--- a/recipes/poke.rb
+++ b/recipes/poke.rb
@@ -4,4 +4,5 @@ aws_swiss node[:aws_swiss][:security_group] do
   rds_name              node[:aws_swiss][:rds_name] # May be nil - but at least one of 'port' or 'rds_name' must be given
   port                  node[:aws_swiss][:port]     # May be nil - but at least one of 'port' or 'rds_name' must be given
   enable                true
+  fallback_group        node [:aws_swiss][:fallback_group] # May be nil
 end

--- a/recipes/poke.rb
+++ b/recipes/poke.rb
@@ -4,5 +4,5 @@ aws_swiss node[:aws_swiss][:security_group] do
   rds_name              node[:aws_swiss][:rds_name] # May be nil - but at least one of 'port' or 'rds_name' must be given
   port                  node[:aws_swiss][:port]     # May be nil - but at least one of 'port' or 'rds_name' must be given
   enable                true
-  fallback_group        node [:aws_swiss][:fallback_group] # May be nil
+  fallback_group        node[:aws_swiss][:fallback_group] # May be nil
 end


### PR DESCRIPTION
RDS security groups only allow 20 ingresses. This PR adds support for a fallback security group in case the primary one is already full.

This PR also adds an `enforce` recipe that brings the security group(s) into compliance with a given list of CIDRs.
